### PR TITLE
[Bugfix] add missing variable

### DIFF
--- a/bw
+++ b/bw
@@ -11,6 +11,7 @@ from subprocess import run
 class App(object):
 
     def __init__(self):
+        field_names = ["id", "name", "user", "folder"]
         field_names_string = ",".join(field_names)
         p = run(
             ["rbw", "list", "--fields", field_names_string],


### PR DESCRIPTION
The variable field_names have gone missing with the last change.
The plugin does not work with out it.
I don't think this needs any more explanation.

Greetings
Tiaryn

